### PR TITLE
Use an asynchronous transport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 0.2.0
 
 Release TBD
 
+- Use the transport provided by ``raven-aiohttp`` by default
+
 Version 0.1.0
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,8 @@ The following configuration settings can be added to the application.
 |                              | associated with all events. Default ``None`` |
 +------------------------------+----------------------------------------------+
 | ``SENTRY_TRANSPORT``         | The HTTP transport class that will be used   |
-|                              | to transmit events. Default ``None``         |
+|                              | to transmit events. Default                  |
+|                              | :class:`~raven_aiohttp.AioHttpTransport`     |
 +------------------------------+----------------------------------------------+
 
 Usage

--- a/henson_sentry.py
+++ b/henson_sentry.py
@@ -5,9 +5,10 @@ import os as _os
 import pkg_resources as _pkg_resources
 
 from henson import Extension
-from raven.base import Client
+from raven import Client
 from raven.conf import defaults
 from raven.utils.imports import import_string
+from raven_aiohttp import AioHttpTransport
 
 __all__ = ('Sentry',)
 
@@ -38,7 +39,7 @@ class Sentry(Extension):
         'SENTRY_RELEASE': None,
         'SENTRY_SITE_NAME': None,
         'SENTRY_TAGS': None,
-        'SENTRY_TRANSPORT': None,
+        'SENTRY_TRANSPORT': AioHttpTransport,
     }
 
     REQUIRED_SETTINGS = (

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'Henson',
-        'raven',
+        'raven-aiohttp',
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
Sentry offers a transport built on top of aiohttp that allows the client
to communicate asynchronously. Since Henson is built on top of asyncio,
this transport fits into the message flow better.
