### PR TITLE
Disable Sentry when no DSN is provided

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 0.3.0
 
 Release TBD
 
+- Allow ``SENTRY_DSN`` to be empty; Sentry will be disabled
+
 Version 0.2.0
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,8 @@ The following configuration settings can be added to the application.
 +------------------------------+----------------------------------------------+
 | ``SENTRY_DSN``               | The data source name used to identify that   |
 |                              | Sentry instance to which to send the logs.   |
+|                              | If no value is provided, Sentry will be      |
+|                              | disabled.                                    |
 +------------------------------+----------------------------------------------+
 | ``RAVEN_IGNORE_EXCEPTIONS``  | Exception types that will be ignored when    |
 |                              | sending exceptions to Sentry.                |

--- a/henson_sentry.py
+++ b/henson_sentry.py
@@ -30,6 +30,7 @@ class Sentry(Extension):
     DEFAULT_SETTINGS = {
         'RAVEN_IGNORE_EXCEPTIONS': (),
         'SENTRY_AUTO_LOG_STACKS': defaults.AUTO_LOG_STACKS,
+        'SENTRY_DSN': None,
         'SENTRY_EXCLUDE_PATHS': (),
         'SENTRY_INCLUDE_PATHS': (),
         'SENTRY_MAX_LENGTH_LIST': defaults.MAX_LENGTH_LIST,
@@ -42,10 +43,6 @@ class Sentry(Extension):
         'SENTRY_TRANSPORT': AioHttpTransport,
     }
 
-    REQUIRED_SETTINGS = (
-        'SENTRY_DSN',
-    )
-
     _client = None
 
     def init_app(self, app):
@@ -56,6 +53,10 @@ class Sentry(Extension):
                 be initialized.
         """
         super().init_app(app)
+
+        if not app.settings['SENTRY_DSN']:
+            app.logger.info('sentry.disabled')
+            return
 
         if not app.settings['SENTRY_NAME']:
             app.settings['SENTRY_NAME'] = app.name

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -2,6 +2,8 @@
 
 import asyncio
 
+from henson_sentry import Sentry
+
 
 def test_capture_exception(sentry, test_app, event_loop, cancelled_future,
                            queue):
@@ -52,3 +54,13 @@ def test_handle_exception_with_ignored_error(sentry, test_app, event_loop,
         test_app._process(cancelled_future, queue, event_loop))
 
     assert not sentry._client._events
+
+
+def test_no_dsn(test_app):
+    """Test that Sentry is disabled when there's no DSN."""
+    # Ensure that there's no DSN set for test_app.
+    del test_app.settings['SENTRY_DSN']
+
+    sentry = Sentry(test_app)
+
+    assert sentry._client is None


### PR DESCRIPTION
If an application tried to use Henson-Sentry without specifying a DSN,
`Sentry` would raise an exception (by way of `Extension`). This meant
that either a value was required in all environments (e.g., production,
staging) or code needed to be changed between environments.

A better approach is for Henson-Sentry to gracefully disable itself when
no DSN is provided. When that happens, a message will be logged in case
the behavior wasn't expected.
