### PR TITLE
Update the Read the Docs domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Henson-Sentry |build status|
 
 A library for integrating Sentry into a Henson application.
 
-* `Documentation <https://henson-sentry.rtfd.org>`_
-* `Installation <https://henson-sentry.readthedocs.org/en/latest/#installation>`_
-* `Changelog <https://henson-sentry.readthedocs.org/en/latest/changes.html>`_
+* `Documentation <https://henson-sentry.readthedocs.io>`_
+* `Installation <https://henson-sentry.readthedocs.io/en/latest/#installation>`_
+* `Changelog <https://henson-sentry.readthedocs.io/en/latest/changes.html>`_
 * `Source <https://github.com/dirn/Henson-Sentry>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@ Henson-Sentry
 =============
 
 Henson-Sentry is a library that helps to easily incorporate logging to
-`Sentry <https://sentry.readthedocs.org>`_ into a
-`Henson <https://henson.readthedocs.org>`_ application.
+`Sentry <https://sentry.readthedocs.io>`_ into a
+`Henson <https://henson.readthedocs.io>`_ application.
 
 Installation
 ============

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version='0.4.0',
     author='Andy Dirnberger',
     author_email='andy@dirnberger.me',
-    url='https://henson-sentry.rtfd.org',
+    url='https://henson-sentry.readthedocs.io',
     description='A library for integrating Sentry into a Henson application',
     long_description=read('README.rst'),
     license='MIT',


### PR DESCRIPTION
Read the Docs has switched from using readthedocs.org to readthedocs.io
for project documentation. It includes the added benefit of having
better HTTPS support.
